### PR TITLE
[ssl_security] Improved SSL security handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,3 @@ COPY /etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY /etc/nginx/conf.d/default-server.conf /etc/nginx/conf.d/default-server.conf
 
 VOLUME /var/log/nginx
-EXPOSE 80

--- a/etc/nginx/conf.d/default-server.conf
+++ b/etc/nginx/conf.d/default-server.conf
@@ -1,33 +1,76 @@
-# Health check site - AWS pings with the ip address of the server as the hostname.
-#
-# This will be replaced once the services are running on different hosts
+# For this to forward requests correctly, there needs to be a linked server
+# called 'upstream' that this can forward to on port 3000. Linking the server
+# will add /etc/hosts entries.
 
 server {
-    listen 80 default_server;
-    server_name _;
+  listen 80 default_server;
 
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log notice;
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log notice;
 
-    location /ping {
-        add_header Content-Type text/plain;
-        return 200 'OK';
+  # ELB calls us over HTTP and doesn't supply the X-Forwarded-Proto header,
+  # and requires a real response rather than a redirect to consider the server as 'up'.
+  #
+  # If the rails app is configured to only allow https requests, this incoming request
+  # would end up as a redirect. So we need to override the X-Forwarded-Proto for ping
+  # requests to always appear as if it was sent over https before it hits the app.
+  #
+  location ~ ^/ping.* {
+    proxy_set_header X-Forwarded-Proto https;       # Override the original call method
+
+    # Pass useful headers to the upstream
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+
+    proxy_redirect off;
+    proxy_next_upstream error;
+
+    proxy_pass http://upstream:3000;
+
+    break;
+  }
+
+  # For everything other than /ping we have to make sure that the client is using
+  # https. We redirect the user to https if not.
+  location / {
+    # Make sure not to remove this without a clear understanding of how the
+    # X-Forwarded-Proto header is forced to HTTPS below.
+    if ($http_x_forwarded_proto != "https") {
+      rewrite ^(.*)$ https://$http_host$1 permanent;
     }
 
-    location / {
-        proxy_set_header Host $host;
+    try_files $uri @upstream_location;
+  }
 
-        # The ELB adds headers so that we have some extra information about the client
-        # and the protocol it originally forwarded for (EBL strips off SSL by default)
-        #
-        # We pass the header on to unicorn, so that it can do things like redirect to SSL
-        proxy_pass_request_headers on;
+  location @upstream_location {
+    # Pass all headers to the host by default
+    proxy_pass_request_headers on;
 
-        proxy_hide_header X-Content-Digest;
-        proxy_hide_header X-Rack-Cache;
-        proxy_hide_header X-Request-Id;
-        proxy_hide_header X-Runtime;
+    # Since we've redirected in the location block above,
+    # and we now know we are processing an https request, pass
+    # this header to the proxied server, so it know it's an https request
+    proxy_set_header X-Forwarded-Proto https;
 
-        proxy_pass http://upstream:3000;
-    }
+    # Since we know we are in the SSL processing block, we can supply the
+    # STS header (it must only be set on SSL requests)
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+
+    # Additional info about the connection:
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    # Drop/hide response headers that might expose information:
+    proxy_hide_header X-Content-Digest;
+    proxy_hide_header X-Rack-Cache;
+    proxy_hide_header X-Request-Id;
+    proxy_hide_header X-Runtime;
+
+    # Don't try redirect to another proxy host if we're down - generate an error instead
+    proxy_redirect off;
+    proxy_next_upstream error;
+
+    proxy_pass http://upstream:3000;
+  }
 }


### PR DESCRIPTION
- The /ping.\* url will always be forwarded to upstream, even if the incoming
  request isn't over SSL
  See http://scottwb.com/blog/2013/10/28/always-on-https-with-nginx-behind-an-elb/
  for more information
- For all other cases, enforce that the user has connected via SSL
- For all SSL connections, set Strict-Transport-Security (the standard says this
  must only be set on SSL requests)
