### PR TITLE
Respond to robots.txt and disallow all

### DIFF
--- a/etc/nginx/conf.d/default-server.conf
+++ b/etc/nginx/conf.d/default-server.conf
@@ -43,6 +43,11 @@ server {
     try_files $uri @upstream_location;
   }
 
+  # Disallow all robots directly, without requiring us to embed a file anywhere
+  location /robots.txt {
+    return 200 "User-agent: *\nDisallow: /";
+  }
+
   location @upstream_location {
     # Pass all headers to the host by default
     proxy_pass_request_headers on;


### PR DESCRIPTION
`curl -v http://docker/robots.txt` now says:

Headers:

```
> GET /robots.txt HTTP/1.1
> User-Agent: curl/7.37.1
> Host: docker
> Accept: */*
>
< HTTP/1.1 200 OK
* Server nginx/1.9.1 is not blacklisted
< Server: nginx/1.9.1
< Date: Thu, 11 Jun 2015 13:42:57 GMT
< Content-Type: text/plain
< Content-Length: 25
< Connection: keep-alive
< Vary: Accept-Encoding
<
```

Body:

```
User-agent: *
Disallow: /
```
